### PR TITLE
WIP Add Instrumented tests CI job

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -27,3 +27,6 @@ kotlin.incremental=false
 # If you want to treat warnings as errors locally, set this property to true
 # in your ~/.gradle/gradle.properties file.
 warningsAsErrors=false
+
+# Enable auto-download of SDK components and accept licenses
+android.builder.sdk.download=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,52 +123,44 @@ jobs:
           sarif_file: './app/'
           category: app
 
-#  instrumented_tests:
-#    name: "Instrumented tests"
-#    runs-on: macos-latest
-#    timeout-minutes: 60
-#    strategy:
-#      fail-fast: true
-#      matrix:
-#        api-level: [ 31 ]
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#
-#      - name: Copy CI gradle.properties
-#        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-#
-#      - name: Set up JDK 21
-#        uses: actions/setup-java@v5
-#        with:
-#          distribution: ${{ env.JAVA_VENDOR }}
-#          java-version: ${{ env.JAVA_VERSION }}
-#
-#      - name: Setup Gradle
-#        uses: gradle/actions/setup-gradle@v5
-#
-#      - name: Enable KVM group perms
-#        if: matrix.job == 'instrumentation' && matrix.os == 'ubuntu-latest'
-#        run: |
-#          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-#          sudo udevadm control --reload-rules
-#          sudo udevadm trigger --name-match=kvm
-#
-#      - name: Run instrumented tests
-#        uses: reactivecircus/android-emulator-runner@v2
-#        with:
-#          api-level: ${{ matrix.api-level }}
-#          target: google_apis
-#          arch: x86_64
-#          force-avd-creation: false
-#          profile: Nexus 6
-#          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-#          disable-animations: true
-#          script: ./gradlew :app:connectedDebugAndroidTest
-#
-#      - name: Upload instrumented test results (XML)
-#        if: ${{ !cancelled() }}
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: instrumented-test-results
-#          path: '**/build/outputs/androidTest-results/connected/**.xml'
+  instrumented_tests:
+    name: "Instrumented tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: ${{ env.JAVA_VENDOR }}
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
+
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run instrumented tests
+        run: ./gradlew :app:ciGroupDebugAndroidTest
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-test-results
+          path: '**/build/reports/androidTests/managedDevice/**'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,10 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: Accept Android SDK licenses
+        run: |
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
+
       - name: Run instrumented tests
         run: ./gradlew :app:ciGroupDebugAndroidTest
 

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -1,5 +1,6 @@
 import com.android.build.api.dsl.ApplicationExtension
 import dev.shtanko.androidlab.configureDetekt
+import dev.shtanko.androidlab.configureGradleManagedDevices
 import dev.shtanko.androidlab.configureKotlinAndroid
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Plugin
@@ -21,6 +22,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             extensions.configure<ApplicationExtension> {
                 configureKotlinAndroid(this)
+                configureGradleManagedDevices(this)
                 defaultConfig.targetSdk = 36
                 testOptions.animationsDisabled = true
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled auto-download of Android SDK components in CI builds.
  * Updated instrumented testing infrastructure to use Gradle managed devices on ubuntu-latest with enhanced setup steps and dependencies.
  * Improved test artifact reporting by capturing HTML test reports from managed device executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->