### PR TITLE
Improve benchmark configuration

### DIFF
--- a/.agents/reference/commands.md
+++ b/.agents/reference/commands.md
@@ -18,7 +18,8 @@ Run commands from the repository root with the Gradle wrapper. JDK 21 is require
 | Android lint | `./gradlew lint` or `./gradlew :module:lintDebug` |
 | Screenshot verification | `./gradlew validateDebugScreenshotTest` and/or `./gradlew verifyRoborazziDebug` |
 | Instrumentation | `./gradlew :app:connectedDebugAndroidTest` with a device or emulator available |
-| Macrobenchmark | `./gradlew :benchmarks:connectedBenchmarkReleaseAndroidTest` |
+| Macrobenchmark | `./gradlew :benchmarks:connectedBenchmarkReleaseAndroidTest` on a stable physical device |
+| Baseline profile generation | `./gradlew :app:generateBaselineProfile` using the declared managed device |
 
 Replace `:module` with the actual Gradle path, for example `:core:navigation`. Use `--tests "fully.qualified.ClassName"` to narrow a unit-test task when iterating.
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ those values; the summary below intentionally avoids copying fast-changing versi
 ./gradlew :app:connectedDebugAndroidTest
 
 # Macrobenchmarks & baseline profile
+# Run timing measurements on a stable, connected physical device.
 ./gradlew :benchmarks:connectedBenchmarkReleaseAndroidTest
+# Generate profiles reproducibly with the managed device declared by :benchmarks.
 ./gradlew :app:generateBaselineProfile
 ```
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,7 @@ android {
         create("benchmark") {
             initWith(buildTypes.getByName("release"))
             matchingFallbacks += listOf("release")
+            signingConfig = signingConfigs.getByName("debug")
             isDebuggable = false
             proguardFiles("benchmark-rules.pro")
         }

--- a/benchmarks/AGENTS.md
+++ b/benchmarks/AGENTS.md
@@ -4,8 +4,9 @@ The root [`AGENTS.md`](../AGENTS.md) applies. This file adds rules for macrobenc
 profiles.
 
 - Keep benchmark code deterministic and target release-like, non-debuggable application builds.
-- Use the managed-device configuration declared by this module unless the task explicitly compares
-  physical devices.
+- Use the declared managed device for deterministic baseline-profile generation. Use a stable
+  physical device for representative timing measurements; emulator results are suitable only for
+  smoke checks and trends tied to the same host.
 - Keep setup outside measured blocks when it is not part of the user journey.
 - Record the scenario, build, device, iterations, baseline, and comparison method with results.
 - Cover stable, important user journeys; do not add traversal solely to increase profile size.

--- a/benchmarks/src/main/java/dev/shtanko/template/benchmarks/BaselineProfileGenerator.kt
+++ b/benchmarks/src/main/java/dev/shtanko/template/benchmarks/BaselineProfileGenerator.kt
@@ -18,18 +18,21 @@ package dev.shtanko.template.benchmarks
 
 import androidx.benchmark.macro.junit4.BaselineProfileRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@LargeTest
 @RunWith(AndroidJUnit4::class)
 class BaselineProfileGenerator {
     @get:Rule
     val baselineProfileRule = BaselineProfileRule()
 
     @Test
-    fun generate() = baselineProfileRule.collect(
-        packageName = "dev.shtanko.template",
+    fun startup() = baselineProfileRule.collect(
+        packageName = TARGET_PACKAGE_NAME,
+        includeInStartupProfile = true,
     ) {
         pressHome()
         startActivityAndWait()

--- a/benchmarks/src/main/java/dev/shtanko/template/benchmarks/BenchmarkConfig.kt
+++ b/benchmarks/src/main/java/dev/shtanko/template/benchmarks/BenchmarkConfig.kt
@@ -14,28 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    alias(libs.plugins.androidlab.android.benchmark)
-}
+package dev.shtanko.template.benchmarks
 
-val baselineProfileDevice = "pixel6Api34"
-
-android {
-    namespace = "dev.shtanko.template.benchmarks"
-
-    testOptions.managedDevices.localDevices {
-        create(baselineProfileDevice) {
-            device = "Pixel 6"
-            apiLevel = 34
-            systemImageSource = "aosp"
-        }
-    }
-
-    targetProjectPath = ":app"
-    experimentalProperties["android.experimental.self-instrumenting"] = true
-}
-
-baselineProfile {
-    managedDevices += baselineProfileDevice
-    useConnectedDevices = false
-}
+internal const val TARGET_PACKAGE_NAME = "dev.shtanko.template"

--- a/benchmarks/src/main/java/dev/shtanko/template/benchmarks/ExampleStartupBenchmark.kt
+++ b/benchmarks/src/main/java/dev/shtanko/template/benchmarks/ExampleStartupBenchmark.kt
@@ -16,26 +16,34 @@
 
 package dev.shtanko.template.benchmarks
 
+import androidx.benchmark.macro.CompilationMode
 import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@LargeTest
 @RunWith(AndroidJUnit4::class)
 class ExampleStartupBenchmark {
     @get:Rule
     val benchmarkRule = MacrobenchmarkRule()
 
     @Test
-    fun startup() = benchmarkRule.measureRepeated(
-        packageName = "dev.shtanko.template",
-        metrics = listOf(androidx.benchmark.macro.StartupTimingMetric()),
-        iterations = 5,
+    fun coldStartupWithoutPreCompilation() = benchmarkRule.measureRepeated(
+        packageName = TARGET_PACKAGE_NAME,
+        metrics = listOf(StartupTimingMetric()),
+        compilationMode = CompilationMode.None(),
+        iterations = 10,
         startupMode = StartupMode.COLD,
-    ) {
-        pressHome()
-        startActivityAndWait()
-    }
+        setupBlock = {
+            pressHome()
+        },
+        measureBlock = {
+            startActivityAndWait()
+        },
+    )
 }

--- a/build-logic/convention/src/main/kotlin/dev/shtanko/androidlab/convention/AndroidBenchmarkConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/shtanko/androidlab/convention/AndroidBenchmarkConventionPlugin.kt
@@ -1,9 +1,11 @@
 package dev.shtanko.androidlab.convention
 
+import com.android.build.api.dsl.TestExtension
 import dev.shtanko.androidlab.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 
 class AndroidBenchmarkConventionPlugin : Plugin<Project> {
@@ -12,15 +14,20 @@ class AndroidBenchmarkConventionPlugin : Plugin<Project> {
             apply(plugin = "androidlab.android.test")
             apply(plugin = "androidx.baselineprofile")
 
+            extensions.configure<TestExtension> {
+                defaultConfig {
+                    minSdk = libs.findVersion("benchmarkMinSdk").get().requiredVersion.toInt()
+                    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+                    testInstrumentationRunnerArguments["listener"] =
+                        "androidx.benchmark.junit4.SideEffectRunListener"
+                }
+            }
+
             dependencies {
                 "implementation"(libs.findLibrary("androidx-benchmark-macro").get())
-                "implementation"(libs.findLibrary("androidx-test-core").get())
-                "implementation"(libs.findLibrary("androidx-espresso-core").get())
                 "implementation"(libs.findLibrary("androidx-test-ext").get())
-                "implementation"(libs.findLibrary("androidx-test-rules").get())
                 "implementation"(libs.findLibrary("androidx-test-runner").get())
                 "implementation"(libs.findLibrary("androidx-uiautomator").get())
-                "implementation"(libs.findLibrary("androidx-junit").get())
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,6 +92,7 @@ androidxSavedStateCompose = "1.5.0"
 
 compileSdk = "37"
 minSdk = "24"
+benchmarkMinSdk = "28"
 targetSdk = "37"
 
 [bundles]


### PR DESCRIPTION
## Summary

- centralize benchmark SDK, instrumentation runner, side-effect listener, and dependencies in the benchmark convention plugin
- generate Baseline Profiles with a reproducible Pixel 6 API 34 AOSP managed device
- keep the target benchmark build release-like and non-debuggable while signing it with the local debug key
- make the cold-start benchmark explicit and deterministic by moving setup outside measurement, using no pre-compilation, and increasing iterations
- include startup code in the Startup Profile and centralize the target package name
- document when to use a physical device versus the managed device

## Why

The benchmark module duplicated shared configuration, enabled an unused `BuildConfig`, inherited release signing, and measured `pressHome()` inside the benchmark block. Its API 33 managed device also missed the more reliable Android 14+ compilation-state behavior. Together these made local setup less portable and measurements less clearly defined.

## Impact

Benchmark APKs remain minified and non-debuggable, but can be installed without production signing credentials. Baseline Profile generation is reproducible through the declared managed device, while representative timing measurements remain assigned to stable physical hardware.

## Validation

- `./gradlew :build-logic:convention:check :benchmarks:spotlessCheck :benchmarks:detekt :benchmarks:assembleBenchmarkRelease :benchmarks:assembleNonMinifiedRelease :app:assembleBenchmark --console=plain`
- `make verify`
- `./gradlew :app:generateBaselineProfile --dry-run --console=plain`
- `git diff --check`

Actual profile generation and timing measurements were not run because they require a managed emulator and a stable physical device, respectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reproducible baseline profile generation using a managed Pixel 6 device.
  * Updated startup benchmarking to measure cold starts without precompilation.
  * Increased benchmark iterations and added startup timing metrics.

* **Bug Fixes**
  * Benchmark builds now use debug signing, improving local benchmark execution.

* **Documentation**
  * Clarified when to use stable physical devices versus managed devices for profiling and timing measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->