### PR TITLE
Improve release configuration and secret protection

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -39,7 +39,9 @@ The skills use the portable `SKILL.md` format. Agents without automatic skill di
 
 ## Optional pre-commit hook
 
-The hook syntax-checks staged shell scripts and runs `spotlessCheck` when staged Kotlin or Gradle Kotlin DSL files are present. Enable it for this clone with:
+The hook rejects sensitive staged paths and common high-confidence credential formats,
+syntax-checks staged shell scripts, and runs `spotlessCheck` when staged Kotlin or Gradle Kotlin DSL
+files are present. Enable it for this clone with:
 
 ```bash
 git config core.hooksPath .agents/hooks

--- a/.agents/hooks/pre-commit
+++ b/.agents/hooks/pre-commit
@@ -5,6 +5,9 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
+printf 'Checking staged files for secrets...\n'
+bash scripts/check-secrets.sh --staged
+
 needs_spotless=false
 
 while IFS= read -r -d '' path; do

--- a/.agents/reference/commands.md
+++ b/.agents/reference/commands.md
@@ -8,6 +8,8 @@ Run commands from the repository root with the Gradle wrapper. JDK 21 is require
 | --- | --- |
 | Documentation only | `make docs-check` |
 | Template tooling | `make template-check` |
+| Sensitive files or credentials | `make secrets-check` |
+| Release signing configuration | `./gradlew :app:validateReleaseSigningConfiguration` |
 | Shell script | `bash -n path/to/script.sh` plus a safe dry run when supported |
 | Pure Kotlin module | `./gradlew :module:test` |
 | Android module | `./gradlew :module:testDebugUnitTest` |
@@ -25,6 +27,12 @@ Replace `:module` with the actual Gradle path, for example `:core:navigation`. U
 `make docs-check` validates local Markdown links, documented Make targets, module references,
 the canonical agent entrypoint, and version-policy consistency without starting Gradle.
 
+`make secrets-check` scans every file in the Git index for forbidden credential paths, private-key
+material, common high-confidence token formats, and hardcoded Android signing passwords. The
+pre-commit hook runs the same scanner against staged additions and modifications. The dedicated
+`secret-check.yml` GitHub Actions workflow runs for every pull request, including documentation-only
+changes that the Android build workflow intentionally skips.
+
 `./gradlew detekt` runs the standard and Compose rule sets across all Kotlin sources. In modules
 that apply `androidlab.kotlin.explicit-visibility`, it also fails on eligible declarations without
 an explicit visibility modifier.
@@ -40,14 +48,27 @@ For a cross-module or pre-PR change, use the canonical non-mutating verification
 make verify
 ```
 
-It validates documentation and template tools, checks build logic, assembles debug artifacts, and
-runs unit tests, lint, Detekt, Spotless, Dependency Guard, Compose screenshot validation, and
-Roborazzi verification without requiring release signing. The host-side pull-request job invokes
-this exact target; managed-device tests remain a separate environment-dependent CI job.
+It validates documentation, template tools, and tracked files for secrets; checks build logic;
+assembles debug artifacts; and runs unit tests, lint, Detekt, Spotless, Dependency Guard, Compose
+screenshot validation, and Roborazzi verification without requiring release signing. The host-side
+pull-request job invokes this exact target; managed-device tests remain a separate
+environment-dependent CI job.
 
 Routine verification never records baselines. Use `make screenshot-record`,
 `make roborazzi-record`, or `make dependency-guard-baseline` only when the corresponding change is
 intentional, then review every generated diff.
+
+## Release build
+
+Run `make generate-release-key` to interactively create a new upload keystore and the ignored local
+signing properties file. The generator refuses to overwrite either output.
+
+Run `make release` to build the signed release Android App Bundle. It reads a complete untracked
+`key.properties` file locally or the complete documented signing environment on CI, disables
+configuration caching for the signing invocation, and fails if credentials or the keystore are
+missing. Routine `make verify` and pull-request CI remain debug-only and do not require release
+secrets. See [`RELEASING.md`](../../RELEASING.md) for credential setup and the protected manual
+GitHub Actions workflow.
 
 ## Mutating commands
 

--- a/.agents/reference/decisions.md
+++ b/.agents/reference/decisions.md
@@ -213,6 +213,67 @@ need focused tests.
 enforcement scope expands beyond feature boundaries, or maintaining the custom PSI rule becomes
 more costly than its API-safety benefit.
 
+### AD-009: Release signing is isolated from routine CI
+
+**Status:** Accepted
+
+**Context:** Release packaging needs private key material, while pull requests and routine
+verification execute code that must not receive production credentials. A partially configured
+signing block can also fail late or produce an unsigned artifact that looks releasable.
+
+**Decision:** Local releases use a complete ignored `key.properties` file. CI releases use a
+separate upload key restored from secrets in the protected `production` GitHub environment. The
+manual release workflow accepts only the default branch, runs `make verify` before entering the
+protected job, builds an AAB with configuration caching disabled, retains the R8 mapping, and
+removes the temporary keystore. Routine CI remains debug-only. Gradle fails release packaging when
+credentials are absent, partial, or point to a missing keystore. Google Play distributions should
+use Play App Signing so the CI credential is an independently resettable upload key.
+
+**Alternatives:** Giving signing secrets to pull-request CI was rejected because untrusted build
+logic and tests would share the credential boundary. Committing an encrypted keystore was rejected
+for the default setup because key rotation and repository history make it harder to operate than a
+small environment secret. Storing the app-signing key in GitHub was rejected because Play App
+Signing permits a lower-impact upload key. Automatic Play publication was deferred to keep the
+initial release path reviewable and avoid another long-lived credential.
+
+**Consequences:** Releases require explicit environment setup and approval, and the AAB is uploaded
+to Play manually. Signing credentials are exposed only to trusted release build logic. Adding
+automatic store publication, tag-based triggers, another distribution store, or a different key
+management system requires revisiting this boundary.
+
+**Review when:** GitHub offers a practical hardware-backed signing integration, Play publication is
+automated, releases must originate from tags, or the encoded keystore exceeds GitHub's secret-size
+limit.
+
+### AD-010: Secret prevention uses local, CI, and host layers
+
+**Status:** Accepted
+
+**Context:** Ignore rules prevent ordinary accidental staging but can be bypassed with force-add,
+renamed credentials, copied private-key text, or a contributor who has not installed repository
+hooks. A local regex scanner alone cannot recognize every provider token accurately.
+
+**Decision:** The tracked pre-commit hook scans staged blobs for forbidden sensitive paths and
+high-confidence credential content. The canonical `make verify` contract and a dedicated,
+read-only GitHub Actions workflow scan the complete Git index. The dedicated workflow has no path
+exclusions, so documentation-only pull requests are covered independently of local hook
+installation. Findings report only path and rule, never matched values. Repository administrators
+should also enable GitHub Secret Protection and push protection when available.
+
+**Alternatives:** Relying only on `.gitignore` was rejected because force-add and content copied into
+ordinary source files bypass path ignores. Relying only on a local hook was rejected because hooks
+are not installed automatically and can be skipped. Adding a third-party scanner action was
+deferred because the repository-owned high-confidence baseline and GitHub's native provider-aware
+scanner avoid another executable supply-chain dependency.
+
+**Consequences:** Common signing containers, credential files, private keys, and token formats fail
+before commit or in PR CI without exposing their values in logs. False positives require review and
+a narrow rule adjustment. Unknown or novel secret formats still depend on GitHub scanning and human
+review.
+
+**Review when:** False-positive or miss data justifies adopting a dedicated scanner, GitHub changes
+Secret Protection availability, or the repository introduces legitimate private-key test fixtures.
+
 ## New decision template
 
 ```markdown

--- a/.agents/reference/security.md
+++ b/.agents/reference/security.md
@@ -57,8 +57,33 @@ activity, service, receiver, or provider requires an explicit use case and secur
 - Values placed in resources, assets, native code, or `BuildConfig` can be recovered from an APK.
   Treat every client-side value as configuration, not secure secret storage.
 - Keep privileged API credentials and authorization enforcement on a trusted backend.
-- Preserve the documented CI environment-variable contract for release signing.
+- Use Play App Signing with a separate upload key when distributing through Google Play. Do not
+  place the app-signing key in developer or CI release configuration.
+- Preserve the documented CI environment-variable contract for release signing:
+  `SIGNING_KEYSTORE_PATH`, `SIGNING_STORE_PASSWORD`, `SIGNING_KEY_ALIAS`, and
+  `SIGNING_KEY_PASSWORD`. All four values must come from the same source.
+- Limit signing secrets to the protected `production` GitHub environment and the release build
+  step. Pull-request and routine CI jobs must remain secret-free and must not package release
+  artifacts.
+- Disable Gradle configuration caching for signed release invocations so credentials are not
+  serialized into a reusable project configuration-cache entry.
 - Use the repository's template debug keystore only for local/template purposes.
+
+### Leak prevention
+
+- Enable the repository's pre-commit hook with `git config core.hooksPath .agents/hooks`. It scans
+  staged Git blobs, so unstaged working-tree content does not create false findings.
+- Keep `make secrets-check` in the canonical `make verify` contract and the lightweight
+  `secret-check.yml` workflow so every pull request scans tracked files, including
+  documentation-only changes, even when a contributor does not install the local hook.
+- Require the workflow's `Reject committed secrets` check in the default branch ruleset so a failed
+  scan blocks merges.
+- Treat the repository-owned scanner as a fast baseline, not a complete secret detector. Enable
+  GitHub Secret Protection and push protection where the repository visibility and plan support
+  them; provider-aware scanning covers token formats that local filename and regex rules cannot.
+- Never print a detected value in hook or CI output. Report only the path and detection rule.
+- A committed secret is compromised even if a later commit deletes it. Revoke or rotate it first,
+  then remove it from reachable history when the incident response requires that cleanup.
 
 ## Permissions and privacy
 
@@ -75,6 +100,8 @@ activity, service, receiver, or provider requires an explicit use case and secur
   their transitive surface with Dependency Guard.
 - Prefer narrowly scoped CI permissions. A job that only reads and verifies code should not receive
   write permissions.
+- Build releases only from the default branch after the canonical host checks pass. Gate access to
+  release secrets with environment protection rules where the repository plan supports them.
 - Review third-party build actions and plugins before adoption; pin and update them through the
   repository's dependency-maintenance process.
 - Do not automatically accept a new dependency baseline without reviewing why the dependency graph

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -36,4 +36,5 @@
 - [ ] I listed which tests were selected and why they are proportionate to the change.
 - [ ] Screenshot, dependency, lint, or baseline-profile changes are intentional and reviewed.
 - [ ] I assessed security, privacy, performance, documentation, and agent-guidance impacts.
+- [ ] I confirmed that no credentials, private keys, or production signing files are included.
 - [ ] I created or updated an architectural decision record when the change introduces a durable project-wide constraint.

--- a/.github/template-cleanup/README.md
+++ b/.github/template-cleanup/README.md
@@ -9,4 +9,6 @@ This is your new Kotlin Android Project! Happy hacking!
 - [x] Create a new template project.
 - [ ] Choose a [LICENSE](https://github.com/%REPOSITORY%/community/license/new?branch=master).
 - [ ] Set your `ORG_GRADLE_PROJECT_NEXUS_USERNAME`, `ORG_GRADLE_PROJECT_NEXUS_PASSWORD`, `ORG_GRADLE_PROJECT_SIGNING_KEY` and `ORG_GRADLE_PROJECT_SIGNING_PWD` secrets in [Settings](https://github.com/%REPOSITORY%/settings/secrets/actions).
+- [ ] Configure the protected `production` environment and upload-key secrets described in
+      [`RELEASING.md`](../../RELEASING.md).
 - [ ] Code some cool apps and libraries 🚀.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
+env:
+  CI: true
+  JAVA_VERSION: 21
+  JAVA_VENDOR: 'zulu'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: "Verify release commit"
+    if: github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ripgrep
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: ${{ env.JAVA_VENDOR }}
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
+
+      - name: Verify
+        run: make verify
+
+  build_release:
+    name: "Build signed release bundle"
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: ${{ env.JAVA_VENDOR }}
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
+
+      - name: Restore upload keystore
+        id: signing
+        shell: bash
+        env:
+          SIGNING_KEYSTORE_BASE64: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SIGNING_KEYSTORE_BASE64}" ]]; then
+            echo "SIGNING_KEYSTORE_BASE64 is not configured in the production environment." >&2
+            exit 1
+          fi
+
+          keystore_path="${RUNNER_TEMP}/release-upload.keystore"
+          umask 077
+          printf '%s' "${SIGNING_KEYSTORE_BASE64}" | base64 --decode > "${keystore_path}"
+          if [[ ! -s "${keystore_path}" ]]; then
+            echo "The restored release keystore is empty." >&2
+            exit 1
+          fi
+          echo "keystore_path=${keystore_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build signed Android App Bundle
+        env:
+          SIGNING_KEYSTORE_PATH: ${{ steps.signing.outputs.keystore_path }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: ./gradlew :app:bundleRelease --no-configuration-cache --no-daemon
+
+      - name: Upload release bundle and R8 mapping
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-${{ github.sha }}
+          path: |
+            app/build/outputs/bundle/release/*.aab
+            app/build/outputs/mapping/release/mapping.txt
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Remove upload keystore
+        if: always()
+        shell: bash
+        run: rm -f "${RUNNER_TEMP}/release-upload.keystore"

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -1,0 +1,28 @@
+name: Secret check
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: secret-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: "Reject committed secrets"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Scan tracked files
+        run: bash scripts/check-secrets.sh --all

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,32 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# Local credentials and release signing material
 key.properties
+keystore.properties
+secrets.properties
+credentials.properties
+.env
+.env.*
+!.env.example
+!.env.sample
+!.env.template
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+service-account*.json
+service_account*.json
+*-service-account.json
+*.jks
+*.keystore
+*.p12
+*.pfx
+*keystore*.base64
+*keystore*.b64
+!/release/app-debug.jks
+
 # Created by .ignore support plugin (hsz.mobi)
 ### macOS template
 # General

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ GRADLE_ARGS ?=
 	help \
 	docs-check \
 	template-check \
+	secrets-check \
 	build \
+	generate-release-key \
+	release \
 	install \
 	test \
 	check \
@@ -37,7 +40,10 @@ help:
 	@echo "Build and verification:"
 	@echo "  docs-check                  Validate documentation links and project facts"
 	@echo "  template-check              Validate rename dry run and module generation"
+	@echo "  secrets-check               Reject tracked credentials and sensitive files"
 	@echo "  build                       Assemble debug artifacts"
+	@echo "  generate-release-key        Create an upload keystore and local signing file"
+	@echo "  release                     Build the signed release Android App Bundle"
 	@echo "  install                     Install the app's debug build"
 	@echo "  test                        Run unit tests"
 	@echo "  check                       Run routine static checks"
@@ -71,8 +77,17 @@ docs-check:
 template-check:
 	bash scripts/check-template-tools.sh
 
+secrets-check:
+	bash scripts/check-secrets.sh
+
 build:
 	$(GRADLE) assembleDebug $(GRADLE_ARGS)
+
+generate-release-key:
+	bash scripts/generate-release-key.sh
+
+release:
+	$(GRADLE) :app:bundleRelease --no-configuration-cache $(GRADLE_ARGS)
 
 install:
 	$(GRADLE) :app:installDebug $(GRADLE_ARGS)
@@ -80,10 +95,10 @@ install:
 test:
 	$(GRADLE) test $(GRADLE_ARGS)
 
-check:
+check: secrets-check
 	$(GRADLE) lint detekt spotlessCheck dependencyGuard $(GRADLE_ARGS)
 
-verify: docs-check template-check
+verify: docs-check template-check secrets-check
 	$(GRADLE) :build-logic:convention:check assembleDebug test lint detekt spotlessCheck dependencyGuard validateDebugScreenshotTest verifyRoborazziDebug $(GRADLE_ARGS)
 
 lint:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ A modern, production-ready Android template built with **Jetpack Compose**, **Na
 # Run the same host-side verification used by pull requests
 make verify
 
+# Scan tracked files for credentials and sensitive release files
+make secrets-check
+
 # Run linting and static analysis
 ./gradlew detekt
 
@@ -76,10 +79,29 @@ make verify
 
 ### Local configuration
 
-For local release signing, use an untracked `key.properties` file with `storeFile`,
-`storePassword`, `keyAlias`, and `keyPassword`. CI keeps the existing
-`SIGNING_STORE_PASSWORD`, `SIGNING_KEY_ALIAS`, and `SIGNING_KEY_PASSWORD` environment-variable
-contract.
+Release builds use an untracked `key.properties` file locally and protected environment secrets in
+GitHub Actions. See [`RELEASING.md`](RELEASING.md) for the copy-ready local file, GitHub secret
+commands, interactive upload-key generator, protected-environment setup, and release workflow.
+
+### Secret leak safeguards
+
+Enable the repository-owned pre-commit hook once per clone:
+
+```bash
+git config core.hooksPath .agents/hooks
+```
+
+The hook checks staged Git blobs without reading ignored local credentials. A lightweight,
+read-only GitHub Actions workflow repeats the check for every pull request, including
+documentation-only changes. After its first run, make **Reject committed secrets** a required
+status check in the default branch ruleset.
+
+Repository administrators should also enable GitHub Secret Protection and push protection under
+**Settings → Security → Advanced Security** when available; native provider-aware scanning
+complements the repository's intentionally small, high-confidence rule set.
+
+If a real credential is ever committed, revoke or rotate it immediately. Removing it in a later
+commit does not make the exposed value safe.
 
 ## 🏗️ Project Architecture
 
@@ -165,7 +187,7 @@ those values; the summary below intentionally avoids copying fast-changing versi
 - **Baseline Profiles** — generated via `:benchmarks` for faster startup and smoother frames.
 - **Screenshot Testing** — automated UI regression with Roborazzi + the Compose screenshot plugin.
 - **Dependency Guard** — locks transitive dependency surface across builds.
-- **Signing-ready** — release `signingConfig` resolves keystore credentials from env vars on CI (`SIGNING_STORE_PASSWORD`, `SIGNING_KEY_ALIAS`, `SIGNING_KEY_PASSWORD`) or an untracked `key.properties` file locally.
+- **Signing-ready** — local builds use an ignored credential file, while a manually approved GitHub Actions workflow restores an upload key only on its ephemeral runner and retains the signed AAB plus R8 mapping.
 
 ## 🧪 Testing
 
@@ -198,6 +220,7 @@ The `Makefile` wraps common Gradle invocations:
 
 - `make` / `make help` — list available targets without changing the project.
 - `make docs-check` — validate documentation links and project facts.
+- `make secrets-check` — reject tracked credentials and sensitive release files.
 - `make build` / `make install` — assemble or install the debug app.
 - `make test` — run unit tests.
 - `make check` — run lint, Detekt, Spotless, and Dependency Guard checks.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,178 @@
+# Release signing
+
+The recommended setup is to use [Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play)
+and keep only the separate **upload key** on developer machines and GitHub Actions. Google Play
+protects the app-signing key, while a lost or compromised upload key can be reset without changing
+the identity of the installed app.
+
+If the app is already published, use the upload key currently registered in Play Console. Do not
+replace it with a newly generated key unless the Play Console upload-key reset process is complete.
+
+Do not commit a production keystore, passwords, `key.properties`, or a Base64-encoded key. Keep an
+independent encrypted backup of the upload keystore and its credentials.
+
+## Local release
+
+### Generate a new upload key
+
+For a new app, run the interactive generator:
+
+```bash
+make generate-release-key
+```
+
+It creates `release/upload-keystore.p12` and `key.properties` by default, refuses to overwrite
+either file, applies owner-only permissions, and prompts for one strong password used for both the
+keystore and key. Choose an external keystore path when prompted if you do not want the key stored
+under the ignored repository tree.
+
+The equivalent command with explicit certificate identity is:
+
+```bash
+scripts/generate-release-key.sh \
+  --keystore /absolute/path/to/upload-keystore.p12 \
+  --alias upload \
+  --dname "CN=Your Name, OU=Mobile, O=Your Organization, C=PT"
+```
+
+The generated PKCS#12 keystore contains a 4096-bit RSA upload certificate valid for 10,000 days,
+which exceeds Android's recommended minimum of 25 years. The script uses JDK `keytool`, so select
+the repository's required JDK before running it.
+
+If the app is already published, do not generate a replacement unless Play Console expects a new
+upload certificate as part of its upload-key reset process.
+
+### Configure an existing key
+
+1. Copy the tracked example:
+
+   ```bash
+   cp key.properties.example key.properties
+   chmod 600 key.properties
+   ```
+
+2. Fill in all four values:
+
+   ```properties
+   storeFile=/absolute/path/to/upload-keystore.p12
+   storePassword=your-keystore-password
+   keyAlias=your-upload-key-alias
+   keyPassword=your-key-password
+   ```
+
+   An absolute keystore path outside the repository is preferred. `key.properties`, `*.jks`,
+   `*.keystore`, `*.p12`, and `*.pfx` are ignored as a second line of defense, but ignored files can
+   still be exposed by backups, logs, or accidental force-adds.
+
+3. Build the signed Android App Bundle:
+
+   ```bash
+   make release
+   ```
+
+The bundle is written under `app/build/outputs/bundle/release/`. A release task fails with a clear
+error if the file is missing, any value is blank, or the keystore path does not exist. Debug builds
+do not require release credentials.
+
+Before each Play upload, increment and commit `versionCode` and update `versionName` when
+appropriate.
+
+## GitHub Actions release
+
+The manual [`Release`](.github/workflows/release.yml) workflow:
+
+1. accepts runs only from the repository's default branch;
+2. runs the same host verification as pull requests before requesting signing access;
+3. waits on the protected `production` environment;
+4. reconstructs the upload keystore in the ephemeral runner's temporary directory;
+5. builds a signed AAB with Gradle configuration caching disabled for the signing invocation;
+6. uploads the AAB and R8 `mapping.txt` as a short-lived workflow artifact; and
+7. removes the temporary keystore even when the build fails.
+
+It intentionally does not publish to Google Play. Download and inspect the workflow artifact, then
+upload the AAB through Play Console. This keeps the first version of the release pipeline small and
+avoids adding a Play service-account credential. Automated Play upload can be added later as a
+separate deployment step in the same protected environment.
+
+### 1. Create and protect the environment
+
+In the repository, open **Settings → Environments → New environment** and create `production`.
+Restrict deployment branches to the default branch. When the repository plan supports it, add a
+required reviewer and prevent self-review. Environment secrets are unavailable to the release job
+until its protection rules pass.
+
+If environment secrets are unavailable for a private repository on the current GitHub plan, add
+the same four names under **Settings → Secrets and variables → Actions → Repository secrets**. The
+workflow does not change, but approval no longer gates access to those repository-level secrets;
+the protected environment is the preferred setup.
+
+### 2. Add four environment secrets
+
+Open **Settings → Environments → production → Environment secrets** and add:
+
+| Secret | Value |
+| --- | --- |
+| `SIGNING_KEYSTORE_BASE64` | Base64 text of the upload keystore file |
+| `SIGNING_STORE_PASSWORD` | Keystore password |
+| `SIGNING_KEY_ALIAS` | Upload-key alias |
+| `SIGNING_KEY_PASSWORD` | Upload-key password |
+
+Base64 is only a binary-to-text encoding; GitHub's encrypted secret storage provides the
+protection. GitHub secrets have a size limit, so confirm the encoded file is below the current
+[GitHub secret limit](https://docs.github.com/en/actions/reference/security/secrets#limits-for-secrets).
+
+With [GitHub CLI](https://cli.github.com/) authenticated for this repository, the keystore secret
+can be uploaded without writing an encoded copy into the project:
+
+macOS:
+
+```bash
+base64 -i /absolute/path/to/upload-keystore.p12 \
+  | gh secret set --env production SIGNING_KEYSTORE_BASE64
+```
+
+Linux:
+
+```bash
+base64 -w 0 /absolute/path/to/upload-keystore.p12 \
+  | gh secret set --env production SIGNING_KEYSTORE_BASE64
+```
+
+Add the three text secrets interactively so they do not enter shell history:
+
+```bash
+gh secret set --env production SIGNING_STORE_PASSWORD
+gh secret set --env production SIGNING_KEY_ALIAS
+gh secret set --env production SIGNING_KEY_PASSWORD
+```
+
+Confirm only the secret names:
+
+```bash
+gh secret list --env production
+```
+
+### 3. Build a release
+
+Commit the intended version and wait for normal CI to pass. Then open **Actions → Release → Run
+workflow**, select the default branch, and approve the `production` environment when prompted.
+Download the `release-<commit SHA>` artifact after the workflow finishes.
+
+## CI signing contract
+
+Gradle accepts either the complete local `key.properties` file or this complete environment
+variable set:
+
+```text
+SIGNING_KEYSTORE_PATH
+SIGNING_STORE_PASSWORD
+SIGNING_KEY_ALIAS
+SIGNING_KEY_PASSWORD
+```
+
+The workflow creates `SIGNING_KEYSTORE_PATH`; it is not a GitHub secret. Sources are never mixed:
+if any signing environment variable is set, all four must be present. This prevents a partially
+configured runner from silently falling back to a developer file.
+
+For key rotation or compromise, follow the Play Console upload-key reset process, replace all four
+`production` secrets together, and retain the old workflow run and Play release records for audit.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,17 +15,28 @@
  */
 import java.util.Properties
 
-val isCiBuild = providers.environmentVariable("CI").map(String::toBoolean).getOrElse(false)
-
 private val storePasswordKey = "storePassword"
 private val keyPasswordKey = "keyPassword"
 private val keyAliasKey = "keyAlias"
 private val storeFileKey = "storeFile"
-private val releaseSigningPropertyKeys = listOf(
+private val releaseSigningKeys = listOf(
     storePasswordKey,
     keyPasswordKey,
     keyAliasKey,
     storeFileKey,
+)
+private val releaseSigningEnvironmentVariables = mapOf(
+    storePasswordKey to "SIGNING_STORE_PASSWORD",
+    keyPasswordKey to "SIGNING_KEY_PASSWORD",
+    keyAliasKey to "SIGNING_KEY_ALIAS",
+    storeFileKey to "SIGNING_KEYSTORE_PATH",
+)
+
+data class ReleaseSigningCredentials(
+    val storeFile: File,
+    val storePassword: String,
+    val keyAlias: String,
+    val keyPassword: String,
 )
 
 val releaseSigningPropertiesFile = rootProject.file("key.properties")
@@ -34,12 +45,61 @@ val releaseSigningProperties = Properties().apply {
         releaseSigningPropertiesFile.inputStream().use(::load)
     }
 }
-val releaseSigningStoreFile = releaseSigningProperties
-    .getProperty(storeFileKey)
-    ?.let(rootProject::file)
-val hasValidLocalReleaseSigningConfig =
-    releaseSigningPropertyKeys.all(releaseSigningProperties::containsKey) &&
-        releaseSigningStoreFile?.isFile == true
+val releaseSigningEnvironmentValues = releaseSigningEnvironmentVariables.mapValues { (_, name) ->
+    providers.environmentVariable(name).orNull
+}
+val hasAnyReleaseSigningEnvironmentValue =
+    releaseSigningEnvironmentValues.values.any { !it.isNullOrBlank() }
+val hasCompleteReleaseSigningEnvironment =
+    releaseSigningEnvironmentValues.values.all { !it.isNullOrBlank() }
+val hasCompleteLocalReleaseSigningProperties =
+    releaseSigningKeys.all { !releaseSigningProperties.getProperty(it).isNullOrBlank() }
+
+val releaseSigningCredentials = when {
+    hasCompleteReleaseSigningEnvironment -> ReleaseSigningCredentials(
+        storeFile = rootProject.file(releaseSigningEnvironmentValues.getValue(storeFileKey)!!),
+        storePassword = releaseSigningEnvironmentValues.getValue(storePasswordKey)!!,
+        keyAlias = releaseSigningEnvironmentValues.getValue(keyAliasKey)!!,
+        keyPassword = releaseSigningEnvironmentValues.getValue(keyPasswordKey)!!,
+    )
+
+    !hasAnyReleaseSigningEnvironmentValue && hasCompleteLocalReleaseSigningProperties ->
+        ReleaseSigningCredentials(
+            storeFile = rootProject.file(releaseSigningProperties.getProperty(storeFileKey)),
+            storePassword = releaseSigningProperties.getProperty(storePasswordKey),
+            keyAlias = releaseSigningProperties.getProperty(keyAliasKey),
+            keyPassword = releaseSigningProperties.getProperty(keyPasswordKey),
+        )
+
+    else -> null
+}
+
+val releaseSigningConfigurationError = when {
+    hasAnyReleaseSigningEnvironmentValue && !hasCompleteReleaseSigningEnvironment -> {
+        val missingVariables = releaseSigningEnvironmentVariables
+            .filterKeys { releaseSigningEnvironmentValues[it].isNullOrBlank() }
+            .values
+            .joinToString()
+        "Release signing environment is incomplete. Missing: $missingVariables."
+    }
+
+    releaseSigningPropertiesFile.isFile && !hasCompleteLocalReleaseSigningProperties -> {
+        val missingProperties = releaseSigningKeys
+            .filter { releaseSigningProperties.getProperty(it).isNullOrBlank() }
+            .joinToString()
+        "Release signing file ${releaseSigningPropertiesFile.path} is incomplete. " +
+            "Missing: $missingProperties."
+    }
+
+    releaseSigningCredentials == null ->
+        "Release signing is not configured. Copy key.properties.example to key.properties " +
+            "for local builds, or configure the production secrets described in RELEASING.md."
+
+    !releaseSigningCredentials.storeFile.isFile ->
+        "Release keystore does not exist: ${releaseSigningCredentials.storeFile.path}"
+
+    else -> null
+}
 
 plugins {
     alias(libs.plugins.androidlab.android.application.compose)
@@ -68,19 +128,11 @@ android {
 
     signingConfigs {
         register("release") {
-            enableV1Signing = true
-            enableV2Signing = true
-
-            if (isCiBuild) {
-                storeFile = file("keystore.jks")
-                storePassword = providers.environmentVariable("SIGNING_STORE_PASSWORD").orNull
-                keyAlias = providers.environmentVariable("SIGNING_KEY_ALIAS").orNull
-                keyPassword = providers.environmentVariable("SIGNING_KEY_PASSWORD").orNull
-            } else if (hasValidLocalReleaseSigningConfig) {
-                storeFile = releaseSigningStoreFile
-                keyAlias = releaseSigningProperties.getProperty(keyAliasKey)
-                keyPassword = releaseSigningProperties.getProperty(keyPasswordKey)
-                storePassword = releaseSigningProperties.getProperty(storePasswordKey)
+            releaseSigningCredentials?.let { credentials ->
+                storeFile = credentials.storeFile
+                storePassword = credentials.storePassword
+                keyAlias = credentials.keyAlias
+                keyPassword = credentials.keyPassword
             }
         }
     }
@@ -113,6 +165,19 @@ android {
 }
 
 tasks {
+    val validateReleaseSigningConfiguration = register("validateReleaseSigningConfiguration") {
+        group = "verification"
+        description = "Validate credentials required to sign a release artifact"
+
+        doLast {
+            releaseSigningConfigurationError?.let { throw GradleException(it) }
+        }
+    }
+
+    matching { it.name == "validateSigningRelease" }.configureEach {
+        dependsOn(validateReleaseSigningConfiguration)
+    }
+
     getByName("check") {
         dependsOn("detekt")
     }

--- a/key.properties.example
+++ b/key.properties.example
@@ -1,0 +1,6 @@
+# Copy this file to key.properties and replace every placeholder.
+# Prefer an absolute path to a keystore stored outside the repository.
+storeFile=/absolute/path/to/upload-keystore.p12
+storePassword=replace-me
+keyAlias=upload
+keyPassword=replace-me

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -157,14 +157,37 @@ check_verification_contract() {
         fail "CI host verification must invoke the canonical make verify target"
     fi
 
+    if ! rg --fixed-strings --quiet \
+        "run: bash scripts/check-secrets.sh --all" \
+        .github/workflows/secret-check.yml; then
+        fail "the dedicated PR secret workflow must scan every tracked file"
+    fi
+
+    if ! rg --quiet '^[[:space:]]{2}pull_request:' .github/workflows/secret-check.yml \
+        || rg --quiet '^[[:space:]]+paths(-ignore)?:' .github/workflows/secret-check.yml; then
+        fail "the dedicated PR secret workflow must run for every pull request path"
+    fi
+
+    if ! rg --quiet '^[[:space:]]*contents:[[:space:]]*read' \
+        .github/workflows/secret-check.yml; then
+        fail "the dedicated PR secret workflow must have read-only repository access"
+    fi
+
     if rg --quiet \
         'dependencyGuardBaseline|update[A-Za-z]+ScreenshotTest|recordRoborazzi|git-auto-commit-action' \
         .github/workflows/ci.yml; then
         fail "CI verification must not update or commit dependency or screenshot baselines"
     fi
 
-    if rg --quiet 'contents: write|pull-requests: write' .github/workflows/ci.yml; then
+    if rg --quiet \
+        'contents: write|pull-requests: write' \
+        .github/workflows/ci.yml \
+        .github/workflows/secret-check.yml; then
         fail "CI verification must not receive broad repository write permissions"
+    fi
+
+    if ! rg --quiet '^verify:.*secrets-check' Makefile; then
+        fail "make verify must run secrets-check before host verification"
     fi
 
     verify_recipe="$(

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Designed and developed by 2026 ashtanko (Oleksii Shtanko)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+readonly REPO_ROOT="$(git rev-parse --show-toplevel)"
+readonly PRIVATE_KEY_PATTERN="-----BEGIN ([A-Z0-9]+ )?PRIVATE"" KEY-----"
+readonly KNOWN_TOKEN_PATTERN="(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|gh[pousr]_[0-9A-Za-z]{36,}|github_pat_[0-9A-Za-z_]{50,}|xox[baprs]-[0-9A-Za-z-]{20,}|sk_live_[0-9A-Za-z]{20,}|npm_[0-9A-Za-z]{36,}|sk-(proj-)?[0-9A-Za-z_-]{32,})"
+readonly GRADLE_SIGNING_PASSWORD_PATTERN="(storePassword|keyPassword)[[:space:]]*=[[:space:]]*['\"][^'\"]+['\"]"
+readonly PROPERTIES_SIGNING_PASSWORD_PATTERN="^(storePassword|keyPassword)[[:space:]]*[:=][[:space:]]*[^[:space:]]+"
+
+MODE="all"
+failures=0
+
+usage() {
+  printf '%s\n' \
+    "Usage: scripts/check-secrets.sh [--all|--staged]" \
+    "" \
+    "  --all     Scan every file in the Git index (default; use in CI)." \
+    "  --staged  Scan only added, copied, modified, or renamed staged files."
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      MODE="all"
+      ;;
+    --staged)
+      MODE="staged"
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'error: unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+cd "$REPO_ROOT"
+
+forbidden_path_reason() {
+  local path="$1"
+  local basename="${path##*/}"
+
+  # This repository intentionally tracks one public template debug key.
+  if [[ "$path" == "release/app-debug.jks" ]]; then
+    return 1
+  fi
+
+  case "$basename" in
+    key.properties | keystore.properties | secrets.properties | credentials.properties)
+      printf 'credential properties file'
+      return 0
+      ;;
+    local.properties)
+      printf 'machine-local Android configuration'
+      return 0
+      ;;
+    .env.example | .env.sample | .env.template)
+      return 1
+      ;;
+    .env | .env.*)
+      printf 'environment file'
+      return 0
+      ;;
+    id_rsa | id_dsa | id_ecdsa | id_ed25519)
+      printf 'SSH private key'
+      return 0
+      ;;
+    service-account*.json | service_account*.json | *-service-account.json)
+      printf 'service-account credential file'
+      return 0
+      ;;
+  esac
+
+  case "$path" in
+    *.jks | *.JKS | *.keystore | *.p12 | *.pfx | *.P12 | *.PFX)
+      printf 'private keystore container'
+      return 0
+      ;;
+    *keystore*.base64 | *keystore*.b64)
+      printf 'encoded keystore'
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+index_blob_matches() {
+  local path="$1"
+  local pattern="$2"
+
+  # Do not use grep -q here: with pipefail it can terminate git cat-file with
+  # SIGPIPE and hide a successful match.
+  git cat-file blob ":$path" 2>/dev/null |
+    LC_ALL=C grep -aE -- "$pattern" >/dev/null
+}
+
+report_content_failure() {
+  local path="$1"
+  local rule="$2"
+
+  printf 'error: suspected secret in %q (rule: %s)\n' "$path" "$rule" >&2
+  failures=$((failures + 1))
+}
+
+scan_path() {
+  local path="$1"
+  local reason
+
+  if reason="$(forbidden_path_reason "$path")"; then
+    printf 'error: forbidden sensitive path %q (%s)\n' "$path" "$reason" >&2
+    failures=$((failures + 1))
+    return
+  fi
+
+  # The allowlisted template debug keystore is binary and intentionally
+  # insecure; it is never valid release signing material.
+  if [[ "$path" == "release/app-debug.jks" ]]; then
+    return
+  fi
+
+  if index_blob_matches "$path" "$PRIVATE_KEY_PATTERN"; then
+    report_content_failure "$path" "private-key material"
+  fi
+
+  if index_blob_matches "$path" "$KNOWN_TOKEN_PATTERN"; then
+    report_content_failure "$path" "known token format"
+  fi
+
+  case "$path" in
+    *.gradle | *.gradle.kts)
+      if index_blob_matches "$path" "$GRADLE_SIGNING_PASSWORD_PATTERN"; then
+        report_content_failure "$path" "hardcoded Android signing password"
+      fi
+      ;;
+    *.properties)
+      if index_blob_matches "$path" "$PROPERTIES_SIGNING_PASSWORD_PATTERN"; then
+        report_content_failure "$path" "hardcoded Android signing password"
+      fi
+      ;;
+  esac
+}
+
+list_paths() {
+  if [[ "$MODE" == "staged" ]]; then
+    git diff --cached --name-only --diff-filter=ACMR -z
+  else
+    git ls-files -z
+  fi
+}
+
+while IFS= read -r -d '' path; do
+  scan_path "$path"
+done < <(list_paths)
+
+if ((failures > 0)); then
+  printf '\nSecret scan failed with %d finding(s).\n' "$failures" >&2
+  printf '%s\n' \
+    "Remove the file or credential from the commit. If a real secret was" \
+    "ever committed, revoke or rotate it; deleting it in a later commit is" \
+    "not sufficient. Review false positives instead of bypassing the check." >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "staged" ]]; then
+  printf 'Staged secret check passed.\n'
+else
+  printf 'Tracked secret check passed.\n'
+fi

--- a/scripts/generate-release-key.sh
+++ b/scripts/generate-release-key.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# Designed and developed by 2026 ashtanko (Oleksii Shtanko)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+readonly REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly DEFAULT_KEYSTORE_PATH="release/upload-keystore.p12"
+readonly DEFAULT_KEY_ALIAS="upload"
+readonly DEFAULT_DISTINGUISHED_NAME="CN=Android Upload Key"
+readonly KEY_VALIDITY_DAYS="10000"
+readonly KEY_SIZE_BITS="4096"
+
+KEYSTORE_INPUT=""
+KEY_ALIAS=""
+DISTINGUISHED_NAME=""
+DRY_RUN=false
+TEMP_DIRECTORY=""
+KEYSTORE_INSTALLED=false
+PROPERTIES_INSTALLED=false
+COMPLETED=false
+
+die() {
+  printf '\033[31merror:\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+info() {
+  printf '\033[36m==>\033[0m %s\n' "$*"
+}
+
+note() {
+  printf '    %s\n' "$*"
+}
+
+warn() {
+  printf '\033[33mwarn:\033[0m %s\n' "$*" >&2
+}
+
+usage() {
+  sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_flag_value() {
+  local flag="$1"
+  local value="${2:-}"
+  [[ -n "$value" && "$value" != --* ]] || die "$flag requires a value"
+}
+
+absolute_path() {
+  local path="$1"
+  if [[ "$path" == /* ]]; then
+    printf '%s\n' "$path"
+  else
+    printf '%s/%s\n' "$REPO_ROOT" "$path"
+  fi
+}
+
+escape_properties_value() {
+  local value="$1"
+  printf '%s' "${value//\\/\\\\}"
+}
+
+cleanup() {
+  unset RELEASE_KEY_PASSWORD CONFIRM_RELEASE_KEY_PASSWORD
+
+  if [[ "$COMPLETED" != true ]]; then
+    if [[ "$PROPERTIES_INSTALLED" == true && -n "${PROPERTIES_PATH:-}" ]]; then
+      rm -f -- "$PROPERTIES_PATH"
+    fi
+    if [[ "$KEYSTORE_INSTALLED" == true && -n "${KEYSTORE_PATH:-}" ]]; then
+      rm -f -- "$KEYSTORE_PATH"
+    fi
+  fi
+
+  if [[ -n "$TEMP_DIRECTORY" && -d "$TEMP_DIRECTORY" ]]; then
+    rm -rf -- "$TEMP_DIRECTORY"
+  fi
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' HUP TERM
+
+# Usage:
+#   scripts/generate-release-key.sh [options]
+#
+# Options:
+#   --keystore PATH    Keystore output (default: release/upload-keystore.p12)
+#   --alias NAME       Upload-key alias (default: upload)
+#   --dname NAME       X.500 certificate name (default: CN=Android Upload Key)
+#   --dry-run          Validate and print output paths without creating files
+#   -h, --help         Show this help
+#
+# The script prompts for one password and uses it for both the keystore and key.
+# For non-interactive use, provide RELEASE_KEY_PASSWORD through a protected
+# environment rather than as a command-line argument.
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keystore)
+      require_flag_value "$1" "${2:-}"
+      KEYSTORE_INPUT="$2"
+      shift 2
+      ;;
+    --alias)
+      require_flag_value "$1" "${2:-}"
+      KEY_ALIAS="$2"
+      shift 2
+      ;;
+    --dname)
+      require_flag_value "$1" "${2:-}"
+      DISTINGUISHED_NAME="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1 (try --help)"
+      ;;
+  esac
+done
+
+if [[ -z "$KEYSTORE_INPUT" ]]; then
+  if [[ -t 0 ]]; then
+    read -r -p "Keystore path [$DEFAULT_KEYSTORE_PATH]: " KEYSTORE_INPUT
+  fi
+  KEYSTORE_INPUT="${KEYSTORE_INPUT:-$DEFAULT_KEYSTORE_PATH}"
+fi
+
+if [[ -z "$KEY_ALIAS" ]]; then
+  if [[ -t 0 ]]; then
+    read -r -p "Key alias [$DEFAULT_KEY_ALIAS]: " KEY_ALIAS
+  fi
+  KEY_ALIAS="${KEY_ALIAS:-$DEFAULT_KEY_ALIAS}"
+fi
+
+if [[ -z "$DISTINGUISHED_NAME" ]]; then
+  if [[ -t 0 ]]; then
+    read -r -p "Certificate name [$DEFAULT_DISTINGUISHED_NAME]: " DISTINGUISHED_NAME
+  fi
+  DISTINGUISHED_NAME="${DISTINGUISHED_NAME:-$DEFAULT_DISTINGUISHED_NAME}"
+fi
+
+[[ "$KEYSTORE_INPUT" != *$'\n'* ]] || die "keystore path must not contain a newline"
+[[ "$DISTINGUISHED_NAME" != *$'\n'* ]] || die "certificate name must not contain a newline"
+[[ "$KEY_ALIAS" =~ ^[A-Za-z0-9._-]+$ ]] ||
+  die "alias may contain only letters, digits, dots, underscores, and hyphens"
+
+case "$KEYSTORE_INPUT" in
+  *.p12 | *.pfx) ;;
+  *) die "new keystore path must end in .p12 or .pfx" ;;
+esac
+
+KEYSTORE_PATH="$(absolute_path "$KEYSTORE_INPUT")"
+PROPERTIES_PATH="$REPO_ROOT/key.properties"
+
+[[ ! -e "$KEYSTORE_PATH" ]] || die "refusing to overwrite existing keystore: $KEYSTORE_PATH"
+[[ ! -e "$PROPERTIES_PATH" ]] || die "refusing to overwrite existing file: $PROPERTIES_PATH"
+
+command -v keytool >/dev/null 2>&1 ||
+  die "keytool was not found; install or select the repository's required JDK 21"
+
+info "Upload-key configuration"
+note "Keystore:    $KEYSTORE_PATH"
+note "Properties:  $PROPERTIES_PATH"
+note "Alias:       $KEY_ALIAS"
+note "Certificate: $DISTINGUISHED_NAME"
+note "Format:      PKCS12"
+note "Algorithm:   RSA $KEY_SIZE_BITS / SHA-256"
+note "Validity:    $KEY_VALIDITY_DAYS days"
+
+if [[ "$DRY_RUN" == true ]]; then
+  warn "dry run; no key or properties file was created"
+  exit 0
+fi
+
+if [[ -z "${RELEASE_KEY_PASSWORD:-}" ]]; then
+  [[ -t 0 ]] || die "interactive password input requires a terminal"
+  read -r -s -p "Keystore and key password (12+ visible ASCII characters): " \
+    RELEASE_KEY_PASSWORD
+  printf '\n'
+  read -r -s -p "Confirm password: " CONFIRM_RELEASE_KEY_PASSWORD
+  printf '\n'
+  [[ "$RELEASE_KEY_PASSWORD" == "$CONFIRM_RELEASE_KEY_PASSWORD" ]] ||
+    die "passwords do not match"
+fi
+
+LC_ALL=C
+export LC_ALL
+[[ "$RELEASE_KEY_PASSWORD" =~ ^[[:graph:]]{12,}$ ]] ||
+  die "password must contain at least 12 visible ASCII characters and no spaces"
+
+mkdir -p -- "$(dirname "$KEYSTORE_PATH")" "$(dirname "$PROPERTIES_PATH")"
+TEMP_DIRECTORY="$(mktemp -d "${TMPDIR:-/tmp}/android-upload-key.XXXXXX")"
+readonly TEMP_KEYSTORE="$TEMP_DIRECTORY/upload-keystore.p12"
+readonly TEMP_PROPERTIES="$TEMP_DIRECTORY/key.properties"
+
+umask 077
+export RELEASE_KEY_PASSWORD
+
+info "Generating upload key"
+keytool -genkeypair \
+  -keystore "$TEMP_KEYSTORE" \
+  -storetype PKCS12 \
+  -storepass:env RELEASE_KEY_PASSWORD \
+  -keypass:env RELEASE_KEY_PASSWORD \
+  -alias "$KEY_ALIAS" \
+  -keyalg RSA \
+  -keysize "$KEY_SIZE_BITS" \
+  -sigalg SHA256withRSA \
+  -validity "$KEY_VALIDITY_DAYS" \
+  -dname "$DISTINGUISHED_NAME"
+
+keytool -list \
+  -keystore "$TEMP_KEYSTORE" \
+  -storepass:env RELEASE_KEY_PASSWORD \
+  -alias "$KEY_ALIAS" >/dev/null
+
+{
+  printf '# Generated by scripts/generate-release-key.sh. Do not commit this file.\n'
+  printf 'storeFile=%s\n' "$(escape_properties_value "$KEYSTORE_PATH")"
+  printf 'storePassword=%s\n' "$(escape_properties_value "$RELEASE_KEY_PASSWORD")"
+  printf 'keyAlias=%s\n' "$KEY_ALIAS"
+  printf 'keyPassword=%s\n' "$(escape_properties_value "$RELEASE_KEY_PASSWORD")"
+} > "$TEMP_PROPERTIES"
+
+[[ ! -e "$KEYSTORE_PATH" ]] || die "keystore appeared while generating; refusing to overwrite it"
+mv -- "$TEMP_KEYSTORE" "$KEYSTORE_PATH"
+KEYSTORE_INSTALLED=true
+chmod 600 "$KEYSTORE_PATH"
+
+[[ ! -e "$PROPERTIES_PATH" ]] ||
+  die "properties file appeared while generating; refusing to overwrite it"
+mv -- "$TEMP_PROPERTIES" "$PROPERTIES_PATH"
+PROPERTIES_INSTALLED=true
+chmod 600 "$PROPERTIES_PATH"
+
+COMPLETED=true
+unset RELEASE_KEY_PASSWORD CONFIRM_RELEASE_KEY_PASSWORD
+
+info "Upload key created"
+note "Keystore:   $KEYSTORE_PATH"
+note "Properties: $PROPERTIES_PATH"
+note "Build:      make release"
+warn "Back up the keystore and password in separate secure locations before publishing."


### PR DESCRIPTION
## 🚀 Description

- Add fail-fast local and CI release signing configuration with a protected manual release workflow.
- Add an interactive PKCS#12 upload-key generator and complete local/GitHub setup documentation.
- Add layered secret-leak prevention: expanded ignore rules, a staged-file pre-commit check, a full-index scanner in `make verify`, and a lightweight read-only workflow for every pull request.
- Document the release and secret-prevention decisions in the agent guidance and PR checklist.

## 📄 Motivation and impact

The previous signing configuration depended on an implicit CI keystore path and could fail late when credentials were partial or missing. Ignore rules alone also could not stop force-added keystores, copied private keys, or recognized tokens.

After this change, local releases use an ignored `key.properties`, CI releases use four secrets from the protected `production` environment, and routine pull-request CI remains secret-free. The generated `.p12` is a Play upload key; the app-signing key should remain in Play App Signing.

After merge, a repository administrator should:

1. Create and protect the `production` environment and add the four secrets documented in `RELEASING.md`.
2. Enable GitHub Secret Protection and push protection when available.
3. Make **Reject committed secrets** a required status check after its first run.

## 🧪 Validation

- `make verify` — passed; 552 tasks, including build logic, debug assembly, unit tests, lint, Detekt, Spotless, Dependency Guard, and screenshot verification.
- `bash -n scripts/check-secrets.sh scripts/generate-release-key.sh scripts/check-docs.sh .agents/hooks/pre-commit` — passed.
- `bash scripts/generate-release-key.sh --dry-run` — passed.
- Secret-scanner positive/negative fixtures and proposed-index scans — passed without disclosing detected values.
- Workflow YAML parsing and `git diff --check` — passed.
- Disposable PKCS#12 end-to-end signed `:app:bundleRelease --no-configuration-cache` build — passed.

Device tests were not run because this change does not alter runtime Android behavior.

## 🧭 Architecture and maintenance impact

- Module boundaries or public APIs: none.
- Security or privacy: signing credentials are isolated from routine CI; repository checks reject common sensitive paths and high-confidence secret formats without logging values.
- Performance: no runtime impact.
- Documentation or agent guidance: updated README, release guide, command/security references, CI contracts, and PR checklist.
- Architectural decision record: AD-009 and AD-010 document release-signing isolation and layered secret prevention.

## ✅ Checklist

- [x] No production keystore, credential file, private key, or real secret is included.
- [x] Validation is proportionate to the Gradle, shell, CI, and documentation changes.
- [x] Existing benchmark PR #324 and the unrelated local `gradle.properties` edit remain outside this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local and GitHub Actions workflows for generating and validating signed Android release bundles.
  * Added release artifact and R8 mapping uploads for manual releases.
  * Added commands for secret scanning, release-key generation, and release builds.

* **Security**
  * Added automated scanning for credentials, private keys, tokens, and signing passwords across commits and pull requests.
  * Expanded safeguards for local and CI signing files.

* **Documentation**
  * Added setup, release, signing, verification, and secret-handling guidance.
  * Updated contribution checklists and project templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->